### PR TITLE
Added adapter.exists(fileName)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 .nyc_output/
 coverage/
 /test/res/foo.bin
+
+# IntelliJ, WebStorm etc
+.idea/

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Obtain a list of file names accessible through the adapter.
 
 **Returns:** `Promise<string[]>` A Promise that resolves to a file name array.
 
+### `exists(fileName)`
+
+Checks whether the given file name exists.
+
+**Returns:** `Promise<boolean>` A promise returning whether or not this file exists.
+
 ### `createReadStream(fileName)`
 
 Create a read stream for the given file name.

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -80,7 +80,7 @@ DirectoryAdapter.prototype.listFiles = function () {
  */
 DirectoryAdapter.prototype.exists = function (fileName) {
     return new Promise((fulfill) =>
-        fsAccess(this._resolve(fileName), fs.constants.F_OK)
+        fsAccess(this._resolve(fileName), (fs.constants || fs).F_OK)
             .then(() => fulfill(true))
             .catch(() => fulfill(false)));
 };

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -6,6 +6,7 @@ const path = require("path");
 
 const fs = require("fs");
 const fsMkdir = Promise.promisify(fs.mkdir);
+const fsAccess = Promise.promisify(fs.access);
 const fsReaddir = Promise.promisify(fs.readdir);
 const fsRename = Promise.promisify(fs.rename);
 const fsUnlink = Promise.promisify(fs.unlink);
@@ -70,6 +71,18 @@ DirectoryAdapter.prototype.listFiles = function () {
         }
         return [];
     });
+};
+
+/**
+ * Checks whether the given file name exists.
+ *
+ * @return {Promise<boolean>} A promise returning whether or not this file exists.
+ */
+DirectoryAdapter.prototype.exists = function (fileName) {
+    return new Promise((fulfill) =>
+        fsAccess(this._resolve(fileName), fs.constants.F_OK)
+            .then(() => fulfill(true))
+            .catch(() => fulfill(false)));
 };
 
 /**

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -60,6 +60,15 @@ MemoryAdapter.prototype.listFiles = function () {
 };
 
 /**
+ * Checks whether the given file name exists.
+ *
+ * @return {Promise<boolean>} A promise returning whether or not this file exists.
+ */
+MemoryAdapter.prototype.exists = function (fileName) {
+    return Promise.resolve(this.entries.has(fileName));
+};
+
+/**
  * Create a read stream for the given file name.
  *
  * @param {string} fileName The name of the file to read.

--- a/test/directory.test.js
+++ b/test/directory.test.js
@@ -87,6 +87,25 @@ describe("lib/directory.js", function () {
 
     });
 
+    describe("#exists()", function () {
+
+        it("returns false for a non-existant file", function () {
+            const obj = new DirectoryAdapter(RESOURCES_DIR);
+            return expect(obj.exists("doesnotexist.txt")).to.eventually.equal(false);
+        });
+
+        it("returns true for an existing file", function () {
+            const obj = new DirectoryAdapter(RESOURCES_DIR);
+            return expect(obj.exists("test.txt")).to.eventually.equal(true);
+        });
+
+        it("rejects when given nothing", function () {
+            const obj = new DirectoryAdapter(RESOURCES_DIR);
+            return expect(obj.exists()).to.eventually.be.rejected;
+        });
+
+    });
+
     describe("#createReadStream()", function () {
 
         it("throws for missing files", function () {

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -44,6 +44,27 @@ describe("lib/memory.js", function () {
 
     });
 
+    describe("#exists()", function () {
+
+        it("returns false for a non-existant file", function () {
+            const obj = new MemoryAdapter();
+            return expect(obj.exists("foo")).to.eventually.equal(false);
+        });
+
+        it("returns false when given nothing", function () {
+            const obj = new MemoryAdapter();
+            return expect(obj.exists()).to.eventually.equal(false);
+        });
+
+        it("returns true for an existing file", function () {
+            const obj = new MemoryAdapter({
+                "foo": Buffer.alloc(0),
+            });
+            return expect(obj.exists("foo")).to.eventually.equal(true);
+        });
+
+    });
+
     describe("#createReadStream()", function () {
 
         it("throws for missing files", function () {


### PR DESCRIPTION
This PR adds `adapter.exists(fileName)` - a method to check whether or not a file exists. While this is not strictly necessary for reading, it can be particularly useful if you don't want to read a file but simply check if it is present in the adapter.

Additionally, I added `.idea/` to the `.gitignore`, as my IDE of choice (WebStorm) creates this directory and it should not be pushed to the repo.