### PR TITLE
Drop Node 10 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "typescript": "^4.3.5"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/meyfa/fs-adapters",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.20",


### PR DESCRIPTION
This PR drops support for Node versions LESS THAN 12, which are end-of-life.