### PR TITLE
Explicitly forbid sub-directories in DirectoryAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ are interpreted as relative to the base directory, and navigating outside that
 directory (e.g. via `..`) or accessing the directory itself (e.g. via `.`)
 results in an error.
 
+Note that creating or accessing sub-directories is not (yet) supported.
+This might be added in the future, please feel free to make a Pull Request!
+
 #### Constructors
 
 ```js

--- a/lib/directory.ts
+++ b/lib/directory.ts
@@ -22,6 +22,9 @@ export default class DirectoryAdapter extends Adapter {
     if (path.isAbsolute(fileName)) {
       throw new Error('file name must be relative')
     }
+    if (fileName.includes('/') || fileName.includes('\\')) {
+      throw new Error('this adapter does not support file names containing slashes')
+    }
     const abs = path.join(this.directory, fileName)
     const rel = path.relative(this.directory, abs)
     if (rel === '') {

--- a/test/directory.test.ts
+++ b/test/directory.test.ts
@@ -60,6 +60,11 @@ describe('lib/directory.ts', function () {
       const obj = new DirectoryAdapter(RESOURCES_DIR)
       expect(() => callResolve(obj, RESOURCES_DIR + '/foo.bin')).to.throw()
     })
+
+    it('throws for paths containing a slash', function () {
+      const obj = new DirectoryAdapter(RESOURCES_DIR)
+      expect(() => callResolve(obj, 'foo/bar/qux.bin')).to.throw()
+    })
   })
 
   describe('#init()', function () {


### PR DESCRIPTION
This PR makes sure no file names containing slashes are allowed for DirectoryAdapter.

Previously, this would simply result in an error for some methods (such as when writing), while others would work (such as reading), and yet others would fail silently (like listing, which would omit files in sub-directories).

Now, the adapter is explicit in its behavior.

In theory, sub-directories could very well be supported. Yet this incurs a lot more effort on making sure everything works nicely.
Hence, the choice was made to forbid sub-directories completely for now.