### PR TITLE
fix(index): Adapter types not exported

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,3 @@
-import { Adapter } from './lib/adapter'
-import { MemoryAdapter } from './lib/memory-adapter'
-import { DirectoryAdapter } from './lib/directory-adapter'
-
-export = {
-  Adapter,
-  MemoryAdapter,
-  DirectoryAdapter
-}
+export { Adapter } from './lib/adapter'
+export { MemoryAdapter } from './lib/memory-adapter'
+export { DirectoryAdapter } from './lib/directory-adapter'

--- a/test/directory-adapter.test.ts
+++ b/test/directory-adapter.test.ts
@@ -227,12 +227,13 @@ describe('lib/directory-adapter.ts', function () {
       })
     })
 
-    it('obtains readable streams for existing files', function () {
+    it('obtains readable streams for existing files', function (done) {
       const obj = new DirectoryAdapter(RESOURCES_DIR)
       const stream = obj.createReadStream('test.txt')
       expect(stream)
         .to.be.an('object')
         .with.property('read').that.is.a('function')
+      stream.on('close', done)
       stream.destroy()
     })
 
@@ -242,19 +243,20 @@ describe('lib/directory-adapter.ts', function () {
       const stream = obj.createReadStream('test.txt')
       stream.on('data', function (chunk) {
         expect(chunk).to.satisfy((c: Buffer) => expected.equals(c))
+        stream.on('close', done)
         stream.destroy()
-        done()
       })
     })
   })
 
   describe('#createWriteStream()', function () {
-    it('returns writable streams', function () {
+    it('returns writable streams', function (done) {
       const obj = new DirectoryAdapter(RESOURCES_DIR)
       const stream = obj.createWriteStream('foo.bin')
       expect(stream)
         .to.be.an('object')
         .with.property('write').that.is.a('function')
+      stream.on('close', done)
       stream.destroy()
     })
 
@@ -265,7 +267,7 @@ describe('lib/directory-adapter.ts', function () {
       stream.on('finish', function () {
         const writtenData = fs.readFileSync(path.join(RESOURCES_DIR, 'foo.bin'))
         expect(writtenData).to.satisfy((c: Buffer) => data.equals(c))
-        done()
+        stream.on('close', done)
       })
       stream.end(data)
     })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,7 +2,7 @@ import { Adapter } from '../lib/adapter'
 import { MemoryAdapter } from '../lib/memory-adapter'
 import { DirectoryAdapter } from '../lib/directory-adapter'
 
-import index from '../index'
+import * as index from '../index'
 
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'


### PR DESCRIPTION
With the previous syntax, the types could not be used from outside this project other than with the 'typeof' operator.
This PR modifies the export syntax to hopefully also provide the types correctly.