### PR TITLE
chore(ci): Run 'tsc --noEmit' during linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "clean": "rimraf dist",
     "build": "npm run clean && tsc",
     "test": "mocha --require ts-node/register --recursive \"test/**/*.test.*\"",
-    "lint": "eslint --ignore-path .gitignore .",
-    "lint-fix": "eslint --fix --ignore-path .gitignore .",
+    "lint": "eslint --ignore-path .gitignore . && tsc --noEmit",
+    "lint-fix": "eslint --fix --ignore-path .gitignore . && tsc --noEmit",
     "coverage": "nyc --reporter=lcov npm test",
     "prepare": "npm run build"
   },


### PR DESCRIPTION
ESLint by itself does not report type errors, but tsc does, so it is now
executed as well when linting.