### PR TITLE
docs: Remove type annotations from JSDoc comments

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,6 +5,15 @@ extends:
 parserOptions:
   project: './tsconfig.eslint.json'
 
+settings:
+  jsdoc:
+    mode: 'typescript'
+
+rules:
+  'jsdoc/require-param-type': off
+  'jsdoc/require-returns-type': off
+  'jsdoc/no-types': error
+
 overrides:
   - files: 'test/**/*'
     env:

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -13,9 +13,9 @@ function getContentsFrom<E extends OptionalEncoding> (wsb: WritableStreamBuffer,
  * Returns the contents of a writable buffer.
  * If an encoding is specified, the contents are returned as a string, Buffer otherwise.
  *
- * @param {WritableStreamBuffer} wsb The writable buffer.
- * @param {?string} encoding The optional encoding.
- * @returns {Buffer|string} The contents as Buffer or decoded string.
+ * @param wsb The writable buffer.
+ * @param encoding The optional encoding.
+ * @returns The contents as Buffer or decoded string.
  */
 function getContentsFrom (wsb: WritableStreamBuffer, encoding: OptionalEncoding): Buffer | string {
   let result
@@ -33,7 +33,7 @@ export class Adapter {
   /**
    * Initialize this adapter.
    *
-   * @returns {Promise} A Promise for when initialization is done.
+   * @returns A Promise for when initialization is done.
    */
   async init (): Promise<void> {
     // do nothing
@@ -43,7 +43,7 @@ export class Adapter {
    * Obtain a list of file names accessible through this adapter.
    *
    * @abstract
-   * @returns {Promise<string[]>} A Promise that resolves to a file name array.
+   * @returns A Promise that resolves to a file name array.
    */
   async listFiles (): Promise<string[]> {
     throw new Error('not implemented')
@@ -53,8 +53,8 @@ export class Adapter {
    * Checks whether the given file name exists.
    *
    * @abstract
-   * @param {string} fileName The name of the file to check.
-   * @returns {Promise<boolean>} A promise returning whether or not this file exists.
+   * @param fileName The name of the file to check.
+   * @returns A promise returning whether this file exists.
    */
   async exists (fileName: string): Promise<boolean> {
     throw new Error('not implemented')
@@ -64,9 +64,9 @@ export class Adapter {
    * Rename a file.
    *
    * @abstract
-   * @param {string} fileName The old file name.
-   * @param {string} newFileName The new file name.
-   * @returns {Promise} A Promise that resolves when done, or rejects on error.
+   * @param fileName The old file name.
+   * @param newFileName The new file name.
+   * @returns A Promise that resolves when done, or rejects on error.
    */
   async rename (fileName: string, newFileName: string): Promise<void> {
     throw new Error('not implemented')
@@ -76,8 +76,8 @@ export class Adapter {
    * Delete a file.
    *
    * @abstract
-   * @param {string} fileName The name of the file to delete.
-   * @returns {Promise} A Promise that resolves when done, or rejects on error.
+   * @param fileName The name of the file to delete.
+   * @returns A Promise that resolves when done, or rejects on error.
    */
   async delete (fileName: string): Promise<void> {
     throw new Error('not implemented')
@@ -90,8 +90,8 @@ export class Adapter {
    * does not need to be in memory all at once.
    *
    * @abstract
-   * @param {string} fileName The name of the file to read.
-   * @returns {object} A readable stream for the file.
+   * @param fileName The name of the file to read.
+   * @returns A readable stream for the file.
    */
   createReadStream (fileName: string): stream.Readable {
     throw new Error('not implemented')
@@ -101,8 +101,8 @@ export class Adapter {
    * Create a write-stream for the given file name.
    *
    * @abstract
-   * @param {string} fileName The name of the file to write.
-   * @returns {object} A writable stream for the file.
+   * @param fileName The name of the file to write.
+   * @returns A writable stream for the file.
    */
   createWriteStream (fileName: string): stream.Writable {
     throw new Error('not implemented')
@@ -113,9 +113,9 @@ export class Adapter {
    * If an encoding is specified, this will convert the buffer to a string and
    * resolve to that.
    *
-   * @param {string} fileName The name of the file to read.
-   * @param {?(object|string)} options Additional options: encoding.
-   * @returns {Promise<Buffer|string>} Resolves to a Buffer or string, or rejects on error.
+   * @param fileName The name of the file to read.
+   * @param options Additional options: encoding.
+   * @returns Resolves to a Buffer or string, or rejects on error.
    */
   async read (fileName: string, options?: ReadWriteOptions): Promise<Buffer | string> {
     // DEFAULT IMPLEMENTATION
@@ -137,10 +137,10 @@ export class Adapter {
   /**
    * Write to the given file name.
    *
-   * @param {string} fileName The name of the file to write.
-   * @param {Buffer|string} data The data to write.
-   * @param {?(object|string)} options Additional options: encoding.
-   * @returns {Promise} Resolves when done, or rejects on error.
+   * @param fileName The name of the file to write.
+   * @param data The data to write.
+   * @param options Additional options: encoding.
+   * @returns Resolves when done, or rejects on error.
    */
   async write (fileName: string, data: Buffer | string, options?: ReadWriteOptions): Promise<void> {
     // DEFAULT IMPLEMENTATION

--- a/src/directory-adapter.ts
+++ b/src/directory-adapter.ts
@@ -12,7 +12,7 @@ export class DirectoryAdapter extends Adapter {
   /**
    * Construct a new DirectoryAdapter.
    *
-   * @param {string} directory The path to the directory.
+   * @param directory The path to the directory.
    */
   constructor (directory: string) {
     super()

--- a/src/memory-adapter.ts
+++ b/src/memory-adapter.ts
@@ -24,9 +24,8 @@ class ErrorWithCode extends Error {
  * The collection can be another Map, an array of Map-like entries,
  * or a plain object.
  *
- * @param {Map} map The destination Map.
- * @param {object | Map | Array[]} items The item collection.
- * @returns {void}
+ * @param map The destination Map.
+ * @param items The item collection.
  */
 function putAll (map: Map<string, Buffer>, items?: FileContentsMapping): void {
   if (typeof items !== 'object' || items == null) return
@@ -49,7 +48,7 @@ export class MemoryAdapter extends Adapter {
    * The collection can be another Map, an array of Map-like entries,
    * or a plain object.
    *
-   * @param {object | Map | Array[]} initialFiles Existing files.
+   * @param initialFiles Existing files.
    */
   constructor (initialFiles?: FileContentsMapping) {
     super()

--- a/src/util/get-error-code.ts
+++ b/src/util/get-error-code.ts
@@ -1,8 +1,8 @@
 /**
  * Determine if the argument is a non-null object with the property 'code' (which is of some unknown type).
  *
- * @param {*} err The object to check.
- * @returns {boolean} Whether it is safe to access the argument's code property.
+ * @param err The object to check.
+ * @returns Whether it is safe to access the argument's code property.
  */
 function hasCode (err: unknown): err is { code: unknown } {
   if (typeof err !== 'object' || err == null) {
@@ -14,8 +14,8 @@ function hasCode (err: unknown): err is { code: unknown } {
 /**
  * Obtain the argument's code string, if possible, and undefined otherwise.
  *
- * @param {*} err The error argument.
- * @returns {string|undefined} The error code, or undefined if inaccessible.
+ * @param err The error argument.
+ * @returns The error code, or undefined if inaccessible.
  */
 export function getErrorCode (err: unknown): string | undefined {
   return hasCode(err) && typeof err.code === 'string' ? err.code : undefined

--- a/src/util/resolve-encoding.ts
+++ b/src/util/resolve-encoding.ts
@@ -14,8 +14,8 @@ export function resolveEncoding (options: Record<any, any> | BufferEncoding | un
  * Obtain the encoding from an options parameter, which can be either a string
  * or an object with the 'encoding' property.
  *
- * @param {object} options The options parameter.
- * @returns {?string} The encoding, or undefined.
+ * @param options The options parameter.
+ * @returns The encoding, or undefined.
  */
 export function resolveEncoding (options: Record<any, any> | BufferEncoding | undefined | null): BufferEncoding | undefined {
   if (typeof options === 'string') {


### PR DESCRIPTION
Since we're using TypeScript, the information in the comments is
redundant.