### PR TITLE
feat(types): Export ReadWriteOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { Adapter } from './adapter.js'
+export { Adapter, ReadWriteOptions } from './adapter.js'
 export { MemoryAdapter } from './memory-adapter.js'
 export { DirectoryAdapter } from './directory-adapter.js'


### PR DESCRIPTION
This type is useful when implementing a custom adapter in a downstream
package that uses TypeScript. Previously, the "write()" method couldn't
be written properly.